### PR TITLE
feat(footer-modifs) : les liens du footer s'étendaient à plus que l'i…

### DIFF
--- a/components/footer.vue
+++ b/components/footer.vue
@@ -27,6 +27,7 @@ console.log(footer);
   gap: rem(5);
   margin-left: rem(40);
   margin-bottom: rem(40);
+  width: fit-content;
   @include x-large-up {
     margin-left: rem(60);
   }

--- a/pages/legal.vue
+++ b/pages/legal.vue
@@ -46,7 +46,7 @@
   }
   &__footer {
     margin-top: rem(40);
-    padding-bottom: rem(20);
+    padding-bottom: rem(40);
   }
 }
 .content {


### PR DESCRIPTION
# Titre
Footer-modifs

# Description
Les liens du footer s'étendaient à plus que l'icon : rectification pour que seul l'icon dispose d'un lien.